### PR TITLE
Add tox-based build directories.

### DIFF
--- a/plugin/sphinx.vim
+++ b/plugin/sphinx.vim
@@ -5,7 +5,10 @@ endif
 let g:sphinx_html_output_dirs = get(
       \ g:,
       \ 'sphinx_html_output_dirs',
-      \ ['_build/html', 'build/html', '../_build/html', '../build/html', '_build/dirhtml', 'build/dirhtml', '../_build/dirhtml', '../build/dirhtml']
+      \ ['_build/html', '../_build/html', '_build/dirhtml', '../_build/dirhtml', 
+      \  'build/html', '../build/html', 'build/dirhtml', '../build/dirhtml',
+      \  '.tox/docs-dirhtml/tmp/build', '../.tox/docs-dirhtml/tmp/build',
+      \  '.tox/docs-html/tmp/build', '.tox/docs-html/tmp/build']
       \)
 let g:sphinx_doctrees_output_dirs = get(
       \ g:,


### PR DESCRIPTION
Not sure you're up for this, given there are a couple of different conventions folks use for where Sphinx is being built via tox/nox/whatevermakeequivalent.

This is the one I use/recommend, where builds go in `{envtmpdir}/build` for tox -- if so saves me a config option :), but no hard feelings obviously if not.