### PR TITLE
Update injections format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/after/queries/rst/injections.scm
+++ b/after/queries/rst/injections.scm
@@ -4,72 +4,79 @@
 
 ((directive
    name: (type) @_type
-   body: (body (content) @rst))
+   body: (body (content) @injection.content))
  (#any-of?
   @_type
   "toctree"
   "versionadded" "versionchanged" "deprecated" "seealso" "centered" "hlist"
   "glossary"
   "index"
-  "productionlist"))
+  "productionlist")
+ (#set! injection.language "rst"))
 
 ((directive
    name: (type) @_type
-   body: (body (arguments) @rst))
- (#any-of? @_type "sectionauthor" "codeauthor"))
+   body: (body (arguments) @injection.content))
+ (#any-of? @_type "sectionauthor" "codeauthor")
+ (#set! injection.language "rst"))
 
 ;; Code highlight directives
 ((directive
    name: (type) @_type
-   body: (body (arguments) @language (content) @content))
+   body: (body (arguments) @injection.language (content) @injection.content))
  (#eq? @_type "highlight"))
 
 ;; Most directives from domains accept nested content
 ((directive
    name: (type) @_type
-   body: (body (content) @rst))
- (#match? @_type "^(py|c|cpp|js|rst):"))
+   body: (body (content) @injection.content))
+ (#match? @_type "^(py|c|cpp|js|rst):")
+ (#set! injection.language "rst"))
 
 ((directive
    name: (type) @_type
-   body: (body (content) @rst))
- (#any-of? @_type "default-domain" "option" "envar" "program" "describe" "object"))
+   body: (body (content) @injection.content))
+ (#any-of? @_type "default-domain" "option" "envar" "program" "describe" "object")
+ (#set! injection.language "rst"))
 
 ;; Directives from common extensions
 
 ;;; Sphinx docs
 ((directive
    name: (type) @_type
-   body: (body (content) @rst))
- (#eq? @_type "confval"))
+   body: (body (content) @injection.content))
+ (#eq? @_type "confval")
+ (#set! injection.language "rst"))
 
 ;;; sphinx-tabs
 ;;; https://github.com/executablebooks/sphinx-tabs
 ((directive
    name: (type) @_type
-   body: (body (content) @rst))
- (#any-of? @_type "tabs" "tab" "group-tab"))
+   body: (body (content) @injection.content))
+ (#any-of? @_type "tabs" "tab" "group-tab")
+ (#set! injection.language "rst"))
 
 ((directive
    name: (type) @_type
-   body: (body (arguments) @language (content) @content))
+   body: (body (arguments) @injection.language (content) @injection.content))
  (#eq? @_type "code-tab"))
 
 ;;; http domain
 ;;; https://sphinxcontrib-httpdomain.readthedocs.io/
 ((directive
    name: (type) @_type
-   body: (body (content) @rst))
- (#match? @_type "^(http):"))
+   body: (body (content) @injection.content))
+ (#match? @_type "^(http):")
+ (#set! injection.language "rst"))
 
 ((directive
    name: (type) @_type
-   body: (body (arguments) @language (content) @content))
+   body: (body (arguments) @injection.language (content) @injection.content))
  (#eq? @_type "sourcecode"))
 
 ;;; sphinx-prompt
 ;;; https://github.com/sbrunner/sphinx-prompt
 ((directive
    name: (type) @_type
-   body: (body (arguments) @language (content) @content))
+   body: (body (arguments) @injection.language (content) @injection.content))
  (#eq? @_type "prompt"))


### PR DESCRIPTION
The old format was deprecated by neovim.

If you are using an old version of neovim, please pin to the previous commit (ec53a6e7104c6bef75982fce15bcab546c590f7e).